### PR TITLE
fix: use pnpm instead of npm in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,11 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "20"
-      - run: npm ci
-      - run: npm test
+      - uses: pnpm/action-setup@v2
+        with:
+          version: latest
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test
       - uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Replace npm ci with pnpm install --frozen-lockfile to match project's package manager. Fixes CI error where npm ci fails due to missing package-lock.json.

🤖 Generated with [Claude Code](https://claude.ai/code)